### PR TITLE
Typo fixes in python-gets-a-jit.md

### DIFF
--- a/blog/python-gets-a-jit.md
+++ b/blog/python-gets-a-jit.md
@@ -2,7 +2,7 @@ blog_heading: Python 3.13 gets a JIT
 blog_subheading: Reviewing the JIT in Python 3.13
 blog_header_image: posts/snake_cookie_cutter.jpeg
 blog_author: Anthony Shaw
-blog_publish_date: January 9, 2023
+blog_publish_date: January 9, 2024
 blog_card_image: posts/snake_cookie_cutter.jpeg
 ---
 
@@ -87,7 +87,7 @@ For our interpreter, everytime you want to run the function, `func` it has to lo
 
 This is what a JIT does. There are many types of JIT compiler. Numba is a JIT. PyPy has a JIT. Java has lots of JITs. Pyston and Pyjion are JITs.
 
-The JIT that is proposed for Python 3.13 is a copy-any-patch JIT.
+The JIT that is proposed for Python 3.13 is a copy-and-patch JIT.
 
 ## What is a copy-and-patch JIT?
 


### PR DESCRIPTION
Great article, just fixing two typos I happened to notice. I usually don't make a big deal about typos but this one is the first time you're introducing a new term that you go on to explain in depth, and a PR was just as quick as a "Hey you have a typo" message.